### PR TITLE
changed @media screen to just @media

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,7 +32,6 @@ ul{
     background-position: center;
     padding-top: 60px;
 
-
 }
 
 
@@ -566,7 +565,7 @@ button:hover{
 }
 
 
-@media screen and (min-width: 300px)and  (max-width: 650px){
+@media  (min-width: 300px),  (max-width: 650px){
     .nav{
         position: fixed;
         top: 60px;
@@ -638,7 +637,7 @@ button:hover{
 }
 
 
-@media screen and (min-width: 651px)and  (max-width: 900px){
+@media (min-width: 651px),  (max-width: 900px){
     .nav{
         position: fixed;
         top: 60px;


### PR DESCRIPTION
I was testing the responsive design you made on my laptop Ruth. It works fine without error. So i wondered why it wouldn't on mobile. I noticed when you added @media, you included @media screen, but there is also mobile (@media screen mobile). I learnt on my CSS that if you just used @media, instead of @media screen, it will make it responsive to both computer screens and mobile devices. I've changed the tags to just @media and pushed it to test on my mobile.  