### PR TITLE
used margin 0 auto on home p and our team pic to fix when screen wide.

### DIFF
--- a/style.css
+++ b/style.css
@@ -158,7 +158,12 @@ span{
 .home-content{
     display: flex;
     justify-content: space-around;
-    margin-left: 10%;
+    /* margin-left: 5px; */
+    text-align: center;
+    width: 100%;
+    width: 60rem; /* Set your desired fixed width */
+    margin: 0 auto; /* Center the content within this fixed width */
+    
    
     
 }
@@ -277,6 +282,9 @@ span{
     margin: 1rem 1rem;
     border-radius: 100%; 
     justify-content: center;
+    
+    margin: 0 auto; /* Center the content within this fixed width */
+    
    
 
 }


### PR DESCRIPTION
I noticed that as the screen width is made wider and wider on a pc screen, the paragraph in home looks messy and moves across to the right. I added a set width to that section using REM units and added margin: 0 auto. 

The only other issue was with the Our Team pictures. As the the width was increased, the pictures move further and further left not stopping. Adding margin 0 auto fixed this completely. 